### PR TITLE
fix: debug PyPI python versions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     </p>
     <p>
         <a href="https://pypi.org/project/whiteprints"><img alt="PyPI - Project Version" src="https://img.shields.io/pypi/v/whiteprints.svg?logo=PyPI&logoColor=3775A9"/></a>
-        <a href="https://www.python.org"><img alt="PyPI - Python Version" src="https://img.shields.io/pypi/pyversions/whiteprints.svg-306998?logo=Python&logoColor=ffd43b"/></a>
+        <a href="https://www.python.org"><img alt="PyPI - Python Version" src="https://img.shields.io/pypi/pyversions/whiteprints.svg?logo=Python&logoColor=ffd43b"/></a>
         <a href="https://spdx.org/licenses/GPL-3.0-or-later"><img alt="license badge" src="https://img.shields.io/badge/📝_License-GPL--3.0--or--later-4CAF50.svg"/></a>
         <a href="https://github.com/whiteprints/whiteprints/discussions"><img alt="GitHub Discussions" src="https://img.shields.io/github/discussions/whiteprints/whiteprints.svg?logo=GitHub"></a>
         <a href="https://spdx.dev/learn/areas-of-interest/licensing/"><img alt="SPDX Licensing" src="https://img.shields.io/badge/SPDX-licensing-0080FF.svg?logo=SPDX"/></a>


### PR DESCRIPTION
<!--
# Foreword

    We are happy to accept contributions from our users 🚀.

    For more details on how to contribute see
    [CONTRIBUTING.md](https://github.com/whiteprints/whiteprints/blob/main/CONTRIBUTING.md).

    We follow (and lint) Pull Requests names according to
    [Angular commit format](https://gist.github.com/brianclements/841ea7bffdb01346392c#file-commit-formatting-md)
-->

# Description

Please include a quick summary of the change and which issue is fixed.

Please also include relevant motivation and context.

Fixes # (issue)

# Checklist:

  - Quality check

    - I agree to follow this project's [Code of Conduct](https://github.com/whiteprints/whiteprints/blob/main/CODE_OF_CONDUCT.md)
    - I have read the [Contributor Guide](https://github.com/whiteprints/whiteprints/blob/main/CONTRIBUTING.md)
    - I have performed a self-review of my own code
    - I have included relevant tests
    - I have commented my code, particularly in hard-to-understand areas
    - I have made corresponding changes to the documentation

  - By making a contribution to this project, I certify that:

    - The contributor represents and warrants, on behalf of their employer or
      other principal if they are acting within the scope of their employment
      or otherwise as the agent of a legal entity, that they have the right and
      authority to make their contribution under these terms.
    - The contribution was created in whole or in part by me and I have the
      right to submit it under license [GPL-3.0-or-later](https://spdx.org/licenses/GPL-3.0-or-later) license;
      **or**
    - the contribution is based upon previous work that, to the best of my
      knowledge, is covered under an appropriate open source license and I have
      the right under that license to submit that work with modifications,
      whether created in whole or in part by me, under license [GPL-3.0-or-later](https://spdx.org/licenses/GPL-3.0-or-later).
