### PR TITLE
fix: rename flag

### DIFF
--- a/src/whiteprints/cli/command/init.py
+++ b/src/whiteprints/cli/command/init.py
@@ -300,7 +300,7 @@ invocation.
     is_flag=True,
 )
 @click.option(
-    "-p",
+    "-pr",
     "--protect-repository",
     help=_(
         "Configure GitHub to protect branches and tags."


### PR DESCRIPTION
<!--
# Foreword

    We are happy to accept contributions from our users 🚀.

    For more details on how to contribute see
    [CONTRIBUTING.md](https://github.com/whiteprints/whiteprints/blob/main/CONTRIBUTING.md).

    We follow (and lint) Pull Requests names according to
    [Angular commit format](https://gist.github.com/brianclements/841ea7bffdb01346392c#file-commit-formatting-md)
-->

# Description

Please include a quick summary of the change and which issue is fixed.

Please also include relevant motivation and context.

Fixes # (issue)

# Checklist:

  - Quality check

    - I agree to follow this project's [Code of Conduct](https://github.com/whiteprints/whiteprints/blob/main/CODE_OF_CONDUCT.md)
    - I have read the [Contributor Guide](https://github.com/whiteprints/whiteprints/blob/main/CONTRIBUTING.md)
    - I have performed a self-review of my own code
    - I have included relevant tests
    - I have commented my code, particularly in hard-to-understand areas
    - I have made corresponding changes to the documentation

  - By making a contribution to this project, I certify that:

    - The contributor represents and warrants, on behalf of their employer or
      other principal if they are acting within the scope of their employment
      or otherwise as the agent of a legal entity, that they have the right and
      authority to make their contribution under these terms.
    - The contribution was created in whole or in part by me and I have the
      right to submit it under license [GPL-3.0-or-later](https://spdx.org/licenses/GPL-3.0-or-later) license;
      **or**
    - the contribution is based upon previous work that, to the best of my
      knowledge, is covered under an appropriate open source license and I have
      the right under that license to submit that work with modifications,
      whether created in whole or in part by me, under license [GPL-3.0-or-later](https://spdx.org/licenses/GPL-3.0-or-later).


<!-- readthedocs-preview whiteprints start -->
----
📚 Documentation preview 📚: https://whiteprints--16.org.readthedocs.build/en/16/

<!-- readthedocs-preview whiteprints end -->