### PR TITLE
fix: license flag output

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,9 +36,10 @@ Fixes # (issue)
       or otherwise as the agent of a legal entity, that they have the right and
       authority to make their contribution under these terms.
     - The contribution was created in whole or in part by me and I have the
-      right to submit it under license [CC-BY-NC-SA-4.0](https://spdx.org/licenses/CC-BY-NC-SA-4.0) license;
+      right to submit it under the license of the file(s) modified or created;
       **or**
     - the contribution is based upon previous work that, to the best of my
       knowledge, is covered under an appropriate open source license and I have
       the right under that license to submit that work with modifications,
-      whether created in whole or in part by me, under license [CC-BY-NC-SA-4.0](https://spdx.org/licenses/CC-BY-NC-SA-4.0).
+      whether created in whole or in part by me, under the license of the
+      file(s) modified or created.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,9 +172,10 @@ Before submitting changes:
       or otherwise as the agent of a legal entity, that they have the right and
       authority to make their contribution under these terms.
     - The contribution was created in whole or in part by me and I have the
-      right to submit it under license [CC-BY-NC-SA-4.0](../LICENSES/CC-BY-NC-SA-4.0.txt) license; __or__
+      right to submit it under the license of the file(s) modified or created;
+      **or**
     - the contribution is based upon previous work that, to the best of my
       knowledge, is covered under an appropriate open source license and I have
       the right under that license to submit that work with modifications,
-      whether created in whole or in part by me, under the [CC-BY-NC-SA-4.0](../LICENSES/CC-BY-NC-SA-4.0.txt)
-      license.
+      whether created in whole or in part by me, under the license of the
+      file(s) modified of created.

--- a/src/whiteprints/cli/entrypoint.py
+++ b/src/whiteprints/cli/entrypoint.py
@@ -147,6 +147,12 @@ def print_license(ctx: Context, _param: Option, value: bool) -> None:
     console = importlib.import_module("whiteprints.console")
     package_metadata = importlib.import_module("whiteprints.package_metadata")
     console.STDOUT.print(
+        _(
+            "Copyright © 2024 The Whiteprints authors and contributors"
+            " <whiteprints@pm.me>.\n"
+        )
+    )
+    console.STDOUT.print(
         _("Code released under license '{}'.").format(
             package_metadata.__license__
         )


### PR DESCRIPTION
<!--
# Foreword

    We are happy to accept contributions from our users 🚀.

    For more details on how to contribute see
    [CONTRIBUTING.md](https://github.com/whiteprints/whiteprints/blob/main/CONTRIBUTING.md).

    We follow (and lint) Pull Requests names according to
    [Angular commit format](https://gist.github.com/brianclements/841ea7bffdb01346392c#file-commit-formatting-md)
-->

# Description

Please include a quick summary of the change and which issue is fixed.

Please also include relevant motivation and context.

Fixes # (issue)

# Checklist:

  - Quality check

    - I agree to follow this project's [Code of Conduct](https://github.com/whiteprints/whiteprints/blob/main/CODE_OF_CONDUCT.md)
    - I have read the [Contributor Guide](https://github.com/whiteprints/whiteprints/blob/main/CONTRIBUTING.md)
    - I have performed a self-review of my own code
    - I have included relevant tests
    - I have commented my code, particularly in hard-to-understand areas
    - I have made corresponding changes to the documentation

  - By making a contribution to this project, I certify that:

    - The contributor represents and warrants, on behalf of their employer or
      other principal if they are acting within the scope of their employment
      or otherwise as the agent of a legal entity, that they have the right and
      authority to make their contribution under these terms.
    - The contribution was created in whole or in part by me and I have the
      right to submit it under license [CC-BY-NC-SA-4.0](https://spdx.org/licenses/CC-BY-NC-SA-4.0) license;
      **or**
    - the contribution is based upon previous work that, to the best of my
      knowledge, is covered under an appropriate open source license and I have
      the right under that license to submit that work with modifications,
      whether created in whole or in part by me, under license [CC-BY-NC-SA-4.0](https://spdx.org/licenses/CC-BY-NC-SA-4.0).


<!-- readthedocs-preview whiteprints start -->
----
📚 Documentation preview 📚: https://whiteprints--20.org.readthedocs.build/en/20/

<!-- readthedocs-preview whiteprints end -->