### PR TITLE
fix: 🐛 switch to whiteprints-template-context

### DIFF
--- a/src/whiteprints/cli/command/init.py
+++ b/src/whiteprints/cli/command/init.py
@@ -73,7 +73,7 @@ def add_github_functionalities(
                 *copier_args,
             ],
             context=[
-                "jinja2_time",
+                "whiteprints-template-context",
             ],
             trust=True,
         )
@@ -86,7 +86,7 @@ def add_github_functionalities(
                 *copier_args,
             ],
             context=[
-                "jinja2_time",
+                "whiteprints-template-context",
             ],
             trust=True,
         )
@@ -101,7 +101,7 @@ def add_github_functionalities(
                 *copier_args,
             ],
             context=[
-                "jinja2_time",
+                "whiteprints-template-context",
             ],
             trust=True,
         )
@@ -149,9 +149,7 @@ def add_github(
                 *copier_args,
             ],
             context=[
-                "license-expression",
-                "jinja2_time",
-                "copier-templates-extensions",
+                "whiteprints-template-context",
             ],
             trust=True,
         )
@@ -198,7 +196,7 @@ def create_project(
                 *copier_args,
             ],
             context=[
-                "jinja2_time",
+                "whiteprints-template-context",
             ],
             trust=True,
         )


### PR DESCRIPTION
<!--
# Foreword

    We are happy to accept contributions from our users 🚀.

    For more details on how to contribute see
    [CONTRIBUTING.md](https://github.com/whiteprints/whiteprints/blob/main/CONTRIBUTING.md).

    We follow (and lint) Pull Requests names according to
    [Angular commit format](https://gist.github.com/brianclements/841ea7bffdb01346392c#file-commit-formatting-md)

    If this is your first contribution, feel free to add yourself as a
    contributor. To do so comment the pull request with:
    @all-contributors please add @<username> for <contributions>.
    Please refer to the documentation of allcontributors to see the list of
    [contribution types](https://allcontributors.org/docs/en/emoji-key#docsNav)
-->

# Description

https://github.com/whiteprints/template-python moved from in-repository extensions to an external package for maintainability reasons. This forces us to change copier's call to add the new dependency.

This is the second part of #37 

# Checklist:

  - Quality check

    - I agree to follow this project's [Code of Conduct](https://github.com/whiteprints/whiteprints/blob/main/CODE_OF_CONDUCT.md)
    - I have read the [Contributor Guide](https://github.com/whiteprints/whiteprints/blob/main/CONTRIBUTING.md)
    - I have performed a self-review of my own code
    - I have included relevant tests
    - I have commented my code, particularly in hard-to-understand areas
    - I have made corresponding changes to the documentation

  - By making a contribution to this project, I certify that:

    - The contributor represents and warrants, on behalf of their employer or other principal if they are acting within the scope of their employment or otherwise as the agent of a legal entity, that they have the right and authority to make their contribution under these terms.
    - The contribution was created in whole or in part by me and I have the right to submit it under the license of the file(s) modified or created; **or**
    - the contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the license of the file(s) modified or created.


<!-- readthedocs-preview whiteprints start -->
----
📚 Documentation preview 📚: https://whiteprints--39.org.readthedocs.build/en/39/

<!-- readthedocs-preview whiteprints end -->